### PR TITLE
[feature/10] WebSocket에서의 Authorization Header 처리

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -12,6 +12,6 @@ fi
 
 
 echo "> 새 애플리케이션 배포"
-nohup java -jar /home/ec2-user/dikkak-deploy/build/libs/dikkak-0.0.1-SNAPSHOT.jar > /home/ec2-user/nohup.out 2>&1 &
+nohup java -jar /home/ec2-user/dikkak-deploy/build/libs/dikkak-0.0.1-SNAPSHOT.jar --spring.profiles.active=$profile > /home/ec2-user/nohup.out 2>&1 &
 
 exit 0

--- a/src/main/java/com/dikkak/config/JwtAuthorizationFilter.java
+++ b/src/main/java/com/dikkak/config/JwtAuthorizationFilter.java
@@ -58,7 +58,7 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
             Authentication authentication = new UsernamePasswordAuthenticationToken(
                     new UserPrincipal(user.get()), null, AuthorityUtils.NO_AUTHORITIES
             );
-            // 시큐리티 세션에 회원 아이디를 저장
+            // 시큐리티 세션에 회원 정보를 저장
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
         chain.doFilter(request, response);

--- a/src/main/java/com/dikkak/config/StompInterceptor.java
+++ b/src/main/java/com/dikkak/config/StompInterceptor.java
@@ -1,0 +1,43 @@
+package com.dikkak.config;
+
+import com.dikkak.common.BaseException;
+import com.dikkak.common.ResponseMessage;
+import com.dikkak.repository.UserRepository;
+import com.dikkak.service.JwtService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class StompInterceptor implements ChannelInterceptor {
+
+    private final JwtService jwtService;
+    private final UserRepository userRepository;
+
+    private static final String AUTHORIZATION = "Authorization";
+    private static final String BEARER_TOKEN = "Bearer";
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(message);
+        if (!StompCommand.CONNECT.equals(headerAccessor.getCommand())) {
+            return message;
+        }
+
+        String authorization = headerAccessor.getFirstNativeHeader(AUTHORIZATION);
+        if(authorization == null || !authorization.startsWith(BEARER_TOKEN)) {
+            throw new BaseException(ResponseMessage.UNAUTHORIZED_REQUEST);
+        }
+        String token = authorization.substring(7);
+
+        Long userId = jwtService.validateToken(token);
+        userRepository.findById(userId)
+                .orElseThrow(() -> new BaseException(ResponseMessage.UNAUTHORIZED_REQUEST));
+        return message;
+    }
+}

--- a/src/main/java/com/dikkak/config/WebSocketConfig.java
+++ b/src/main/java/com/dikkak/config/WebSocketConfig.java
@@ -1,14 +1,19 @@
 package com.dikkak.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 @Configuration
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final StompInterceptor stompInterceptor;
 
     // 메시지 발행 (publish) 요청   : /pub (Application Destination Prefix)
     // 메시지 구독 (subscribe) 요청 : /sub (enable Simple Broker)
@@ -21,9 +26,13 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         // websocket handshake를 위한 endpoint 지정
-//        registry.addEndpoint("/dikkak-chat").setAllowedOriginPatterns("*"); // ws://~/dikkak-chat
-        registry.addEndpoint("/dikkak-chat")
+        registry.addEndpoint("/dikkak-chat") // ws://~/dikkak-chat
                 .setAllowedOriginPatterns("*");
 //                .withSockJS(); // http://~/dikkak-chat
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(stompInterceptor);
     }
 }

--- a/src/main/java/com/dikkak/controller/coworking/CoworkingSupport.java
+++ b/src/main/java/com/dikkak/controller/coworking/CoworkingSupport.java
@@ -2,6 +2,7 @@ package com.dikkak.controller.coworking;
 
 import com.dikkak.config.UserPrincipal;
 import com.dikkak.entity.coworking.Coworking;
+import com.dikkak.entity.user.User;
 import com.dikkak.entity.user.UserTypeEnum;
 import com.dikkak.service.coworking.CoworkingService;
 import lombok.RequiredArgsConstructor;
@@ -33,5 +34,22 @@ public class CoworkingSupport {
             }
         }
         return coworking;
+    }
+
+    public boolean checkUser(User user, Coworking coworking) {
+        if (user.getUserType().equals(UserTypeEnum.UNDEFINED)) return false;
+
+        if (user.getUserType().equals(UserTypeEnum.ADMIN)) return true;
+        if (user.getUserType().equals(UserTypeEnum.CLIENT)) {
+            if (!user.getId().equals(coworking.getProposal().getClient().getId())) {
+                return false;
+            }
+        }
+        if (user.getUserType().equals(UserTypeEnum.DESIGNER)) {
+            if (!user.getId().equals(coworking.getDesigner().getId())) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/src/main/java/com/dikkak/controller/coworking/MessageController.java
+++ b/src/main/java/com/dikkak/controller/coworking/MessageController.java
@@ -1,8 +1,14 @@
 package com.dikkak.controller.coworking;
 
 import com.dikkak.common.BaseException;
+import com.dikkak.common.ResponseMessage;
 import com.dikkak.config.UserPrincipal;
-import com.dikkak.dto.message.*;
+import com.dikkak.dto.message.FileMessage;
+import com.dikkak.dto.message.FileReq;
+import com.dikkak.dto.message.Message;
+import com.dikkak.dto.message.MessageType;
+import com.dikkak.dto.message.TextMessage;
+import com.dikkak.dto.message.TextReq;
 import com.dikkak.entity.coworking.Coworking;
 import com.dikkak.entity.coworking.CoworkingMessage;
 import com.dikkak.service.coworking.CoworkingService;
@@ -18,20 +24,18 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import static com.dikkak.common.ResponseMessage.INVALID_ACCESS_TOKEN;
-import static com.dikkak.common.ResponseMessage.UNAUTHORIZED_REQUEST;
 
-
-@RestController("")
+@RestController
 @CrossOrigin
 @RequiredArgsConstructor
 @Slf4j
 public class MessageController {
 
     private final SimpMessageSendingOperations simpMessageSendingOperations;
-    private final CoworkingService coworkingService;
     private final MessageService messageService;
+    private final CoworkingService coworkingService;
     private final CoworkingSupport coworkingSupport;
+
 
     /**
      * 외주작업실 텍스트 메시지 전송
@@ -40,15 +44,10 @@ public class MessageController {
      * @param request email, content, coworkingId
      */
     @MessageMapping("/text")
-    public void saveTextMessage(@AuthenticationPrincipal UserPrincipal principal,
-                                TextReq request) {
-
-        if(principal == null) {
-            throw new BaseException(INVALID_ACCESS_TOKEN);
-        }
-        Coworking coworking = coworkingSupport.checkUserAndGetCoworking(principal, request.getCoworkingId());
+    public void saveTextMessage(TextReq request) {
+        Coworking coworking = coworkingService.getCoworking(request.getCoworkingId());
         if(coworking == null) {
-            throw new BaseException(UNAUTHORIZED_REQUEST);
+            throw new BaseException(ResponseMessage.WRONG_COWORKING_ID);
         }
 
         log.info("request= {}", request);
@@ -79,12 +78,12 @@ public class MessageController {
                                 @RequestPart MultipartFile file) {
 
         if(principal == null) {
-            throw new BaseException(INVALID_ACCESS_TOKEN);
+            throw new BaseException(ResponseMessage.INVALID_ACCESS_TOKEN);
         }
 
         Coworking coworking = coworkingSupport.checkUserAndGetCoworking(principal, request.getCoworkingId());
         if(coworking == null) {
-            throw new BaseException(UNAUTHORIZED_REQUEST);
+            throw new BaseException(ResponseMessage.UNAUTHORIZED_REQUEST);
         }
 
         // 파일 저장 & 메시지 저장

--- a/src/main/java/com/dikkak/service/coworking/MessageService.java
+++ b/src/main/java/com/dikkak/service/coworking/MessageService.java
@@ -1,6 +1,7 @@
 package com.dikkak.service.coworking;
 
 import com.dikkak.common.BaseException;
+import com.dikkak.controller.coworking.CoworkingSupport;
 import com.dikkak.dto.message.FileMessage;
 import com.dikkak.dto.message.FileReq;
 import com.dikkak.dto.message.TextReq;
@@ -20,8 +21,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.util.Objects;
 
-import static com.dikkak.common.ResponseMessage.FILE_UPLOAD_FAILED;
-import static com.dikkak.common.ResponseMessage.NON_EXISTENT_EMAIL;
+import static com.dikkak.common.ResponseMessage.*;
 import static org.apache.http.entity.ContentType.*;
 
 @Service
@@ -33,6 +33,7 @@ public class MessageService {
     private final CoworkingFileRepository fileRepository;
     private final UserRepository userRepository;
     private final S3Uploader s3Uploader;
+    private final CoworkingSupport coworkingSupport;
 
     /**
      * 텍스트 메시지 저장
@@ -40,6 +41,10 @@ public class MessageService {
     @Transactional
     public CoworkingMessage saveTextMessage(TextReq req, Coworking coworking) {
         User user = getUser(req.getEmail());
+
+        if (!coworkingSupport.checkUser(user, coworking)) {
+            throw new BaseException(UNAUTHORIZED_REQUEST);
+        }
 
         // coworking message 저장
         return messageRepository.save(

--- a/src/test/java/com/dikkak/service/coworking/MessageServiceTest.java
+++ b/src/test/java/com/dikkak/service/coworking/MessageServiceTest.java
@@ -1,0 +1,127 @@
+package com.dikkak.service.coworking;
+
+import com.dikkak.common.BaseException;
+import com.dikkak.dto.message.TextReq;
+import com.dikkak.dto.proposal.PostProposalReq;
+import com.dikkak.entity.coworking.Coworking;
+import com.dikkak.entity.coworking.CoworkingMessage;
+import com.dikkak.entity.proposal.CategoryEnum;
+import com.dikkak.entity.proposal.Proposal;
+import com.dikkak.entity.user.ProviderTypeEnum;
+import com.dikkak.entity.user.User;
+import com.dikkak.entity.user.UserTypeEnum;
+import com.dikkak.repository.UserRepository;
+import com.dikkak.repository.coworking.CoworkingRepository;
+import com.dikkak.repository.coworking.message.CoworkingMessageRepository;
+import com.dikkak.repository.proposal.ProposalRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.dikkak.common.ResponseMessage.UNAUTHORIZED_REQUEST;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class MessageServiceTest {
+
+    @Autowired
+    MessageService messageService;
+    
+    @Autowired
+    CoworkingMessageRepository messageRepository;
+
+    @Autowired
+    CoworkingRepository coworkingRepository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    ProposalRepository proposalRepository;
+
+    private Proposal proposal;
+    private Coworking coworking;
+
+    @BeforeEach
+    @Transactional
+    void init() {
+        User client = userRepository.save(User.builder()
+                .email("client@naver.com")
+                .providerType(ProviderTypeEnum.KAKAO)
+                .build());
+        User designer = userRepository.save(User.builder()
+                .email("designer@gmail.com")
+                .providerType(ProviderTypeEnum.KAKAO)
+                .build());
+
+        PostProposalReq req = new PostProposalReq();
+        req.setCategory(CategoryEnum.LOGO_OR_CARD);
+        req.setDeadline("2022-08-01");
+        req.setTitle("제목");
+        req.setMainColor("#ffffff");
+        req.setPurpose("목적");
+        proposal = proposalRepository.save(new Proposal(client, req));
+        coworking = coworkingRepository.save(new Coworking(proposal, designer));
+    }
+
+    @AfterEach
+    void tearDown() {
+        messageRepository.deleteAll();
+        coworkingRepository.deleteAll();
+        proposalRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("외주작업실 권한이 있는 회원이 텍스트 메시지를 전송한다.")
+    @Transactional
+    void AuthorizedUserSendTextMessage() {
+        //given
+        User designer = coworking.getDesigner();
+        designer.setUserType(UserTypeEnum.DESIGNER);
+
+        TextReq textReq = new TextReq();
+        textReq.setEmail(designer.getEmail());
+        textReq.setContent("내용");
+        textReq.setCoworkingId(coworking.getId());
+        System.out.println("textReq = " + textReq);
+
+        //when
+        CoworkingMessage message = messageService.saveTextMessage(textReq, coworking);
+
+        //then
+        assertThat(message.getUser()).isEqualTo(designer);
+        assertThat(message.getCoworkingFile()).isNull();
+        assertThat(message.getCoworking()).isEqualTo(coworking);
+        assertThat(message.getContent()).isEqualTo(textReq.getContent());
+    }
+
+    @Test
+    @DisplayName("권한이 없는 회원이 메시지를 전송하면 예외가 발생한다.")
+    @Transactional
+    void UnauthorizedUserSendTextMessage() {
+        //given
+        User user = userRepository.save(User.builder()
+                .email("user@email.com")
+                .providerType(ProviderTypeEnum.KAKAO)
+                .build());
+
+        TextReq textReq = new TextReq();
+        textReq.setEmail(user.getEmail());
+        textReq.setContent("내용");
+        textReq.setCoworkingId(coworking.getId());
+        System.out.println("textReq = " + textReq);
+
+        //when, then
+        BaseException exception = assertThrows(BaseException.class,
+                () -> messageService.saveTextMessage(textReq, coworking));
+        assertThat(exception.getResponseMessage()).isEqualTo(UNAUTHORIZED_REQUEST);
+    }
+}


### PR DESCRIPTION
## 추가한 기능 설명

- Stomp 메시지의 인증 헤더를 검사하기 위한 StompInterceptor 추가
- WebSocketConfig에 StompInterceptor를 등록

Closes #16 
